### PR TITLE
Update route size monitoring dashboard logic

### DIFF
--- a/src/frontend/scss/base/delivery.scss
+++ b/src/frontend/scss/base/delivery.scss
@@ -1,3 +1,7 @@
 .leaflet-routing-alt {
   display: none;
 }
+
+.route-size-monitoring.table tfoot {
+  background-color: #e1f1ff;
+}

--- a/src/page/templates/pages/home.html
+++ b/src/page/templates/pages/home.html
@@ -70,12 +70,12 @@
   <div class="dashboard-stat column">
     <div class="ui segments">
       <div class="ui segment">
-        {% trans 'An overview of the number of main dishes delivered on each route. All active, paused and pending clients are taken into account. Format: "ongoing scheduled dishes (+ episodic and ongoing unscheduled default dishes)"' as route_help_text %}
+        {% trans 'An overview of the number of main dishes delivered on each route. All active, paused and pending clients are taken into account. Format: "scheduled dishes (episodic default dishes)"' as route_help_text %}
         <h3 class="ui blue header">{% trans "Route Size Monitoring" %}<small><i class="help-text question grey icon link" data-content="{{ route_help_text|force_escape }}"></i></small></h3>
       </div>
       <div class="ui secondary blue inverted dashboard left aligned segment" style="justify-content: flex-start; height: inherit">
         <div>
-          <table class="ui very compact striped table">
+          <table class="ui very compact striped table route-size-monitoring">
             <thead>
               <tr>
                 <th class="four wide"></th>
@@ -143,6 +143,45 @@
               </tr>
               {% endfor %}
             </tbody>
+            <tfoot>
+              <tr>
+                <td>
+                  <b>{% trans 'TOTAL' %}</b>
+                </td>
+                <td class="center aligned"></td>
+                <td class="center aligned">
+                    <b>{{ total_scheduled_by_day.monday }}</b>
+                    {% if total_episodic_by_day.monday %}
+                    (+{{total_episodic_by_day.monday}})
+                    {% endif %}
+                  </td>
+                  <td class="center aligned">
+                    <b>{{ total_scheduled_by_day.tuesday }}</b>
+                    {% if total_episodic_by_day.tuesday %}
+                    (+{{total_episodic_by_day.tuesday}})
+                    {% endif %}
+                  </td>
+                  <td class="center aligned">
+                    <b>{{ total_scheduled_by_day.wednesday }}</b>
+                    {% if total_episodic_by_day.wednesday %}
+                    (+{{total_episodic_by_day.wednesday}})
+                    {% endif %}
+                  </td>
+                  <td class="center aligned"></td>
+                  <td class="center aligned">
+                    <b>{{ total_scheduled_by_day.friday }}</b>
+                    {% if total_episodic_by_day.friday %}
+                    (+{{total_episodic_by_day.friday}})
+                    {% endif %}
+                  </td>
+                  <td class="center aligned">
+                    <b>{{ total_scheduled_by_day.saturday }}</b>
+                    {% if total_episodic_by_day.saturday %}
+                    (+{{total_episodic_by_day.saturday}})
+                    {% endif %}
+                  </td>
+                </tr>
+            </tfoot>
           </table>
         </div>
       </div>

--- a/src/page/views.py
+++ b/src/page/views.py
@@ -31,12 +31,15 @@ class HomeView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
         billable_orders_year = Order.objects.filter(
             status='D',
             delivery_date__year=datetime.today().year).count()
+        route_table = self.calculate_route_table()
         context['active_clients'] = active_clients
         context['pending_clients'] = pending_clients
         context['birthday'] = birthday_clients
         context['billable_orders_month'] = billable_orders
         context['billable_orders_year'] = billable_orders_year
-        context['routes'] = self.calculate_route_table()
+        context['routes'] = route_table
+        context['total_scheduled_by_day'] = self.calculate_total_scheduled_by_day(route_table)
+        context['total_episodic_by_day'] = self.calculate_total_episodic_by_day(route_table)
         return context
 
     def calculate_route_table(self):
@@ -63,24 +66,41 @@ class HomeView(LoginRequiredMixin, PermissionRequiredMixin, TemplateView):
 
         route_table = []
         for route in routes:
-            defaults = collections.defaultdict(int)
+            episodic_defaults = collections.defaultdict(int)
             schedules = collections.defaultdict(int)
             for client in route.selected_clients:
+                # meals_schedule are only for ongoing clients
                 meals_schedule = dict(client.meals_schedule)
-                meals_default = dict(client.meals_default)
 
                 # For each day, if there's a schedule, count schedule.
-                # Otherwise, count default.
                 for day, _ in DAYS_OF_WEEK:
                     if day in meals_schedule:
                         schedules[day] += meals_schedule[day].get(
                             'main_dish') or 0
-                    else:
-                        defaults[day] += meals_default[day].get(
-                            'main_dish') or 0
 
-            route_table.append((route.name, defaults, schedules))
+                if client.delivery_type == 'E':  # Episodic
+                    meals_default = dict(client.meals_default)
+                    for day, _ in DAYS_OF_WEEK:
+                        episodic_defaults[day] += meals_default[day].get('main_dish') or 0
+
+            route_table.append((route.name, episodic_defaults, schedules))
         return route_table
+
+    def calculate_total_scheduled_by_day(self, route_table):
+        total_scheduled_by_day = {}
+        for day, _ in DAYS_OF_WEEK:
+            total_scheduled_by_day[day] = 0
+            for route_entry in route_table:
+                total_scheduled_by_day[day] += route_entry[2][day]
+        return total_scheduled_by_day
+
+    def calculate_total_episodic_by_day(self, route_table):
+        total_episodic_by_day = {}
+        for day, _ in DAYS_OF_WEEK:
+            total_episodic_by_day[day] = 0
+            for route_entry in route_table:
+                total_episodic_by_day[day] += route_entry[1][day]
+        return total_episodic_by_day
 
 
 def custom_login(request):


### PR DESCRIPTION
Fixes #3.

> The number shown in parenthesis should ONLY reflect the hypothetical number of meals (according to their MEAL DEFAULTS and regardless of SIZES) that could be ordered by EPISODIC clients (ACTIVE, PAUSED and PENDING) if they all ordered on that given delivery day.

@JeanFrancoisFournier Je ne suis pas 100% certain que mes changements implémentent correctement la logique demandée. Nous allons devoir tester ensemble avant de merger le code.