### PR TITLE
Show upcoming orders when modifying a client's status (#64)

### DIFF
--- a/souschef/member/models.py
+++ b/souschef/member/models.py
@@ -673,6 +673,13 @@ class Client(models.Model):
         return self.client_order.all()
 
     @property
+    def upcoming_orders(self):
+        """
+        Returns upcoming orders associated to this client
+        """
+        return self.client_order.filter(delivery_date__gte=datetime.date.today()).all()
+
+    @property
     def food_preparation(self):
         """
         Returns specific food preparation associated to this client

--- a/souschef/member/templates/client/partials/order_list.html
+++ b/souschef/member/templates/client/partials/order_list.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+
+<table class="ui very basic stripped celled table">
+    <thead>
+        <th class="sorted descending">{% trans 'Order' %}
+                <i class="help-text question grey icon link" data-content="{% trans 'A unique identifier for the order.' %}"></i>
+        </th>
+        <th class="">{% trans 'Delivery Date' %}
+            <i class="help-text question grey icon link" data-content="{% trans 'The delivery date planned for the order.' %}"></i>
+        </th>
+        <th class="center aligned">{% trans 'Status' %}
+            <i class="help-text question grey icon link" data-content="{% trans 'The order status' %}"></i>
+        </th>
+        <th class="">{% trans 'Amount' %}
+            <i class="help-text question grey icon link" data-content="{% trans 'Total amount in $CAD.' %}"></i>
+        </th>
+        <th class="">{% trans 'Actions' %}</th>
+      </thead>
+    </thead>
+    <tbody>
+        {% for order in orders %}
+            <tr>
+                <td><strong><i class="hashtag icon"></i>{{order.id}}</strong></td>
+                <td>{{order.delivery_date}}</td>
+                <td class="center aligned">{{order.get_status_display}}</td>
+                <td><i class="dollar icon"></i>{{order.price}}</td>
+                <td>
+                    <a class="ui basic icon button"  href="{% url 'order:view' pk=order.id %}"><i class="icon unhide"></i></a>
+                    {% if can_edit_data %}<a class="ui basic icon button"  href="{% url 'order:update' pk=order.id %}"><i class="icon edit"></i></a>{% endif %}
+                    {% if can_edit_data %}<a class="ui basic icon button order-delete" href="#" data-order-id="{{order.id}}"><i class="icon trash"></i></a>{% endif %}
+                </td>
+            </tr>
+            {% if can_edit_data %}{% include "order_confirm_delete.html" %}{% endif %}
+        {% endfor %}
+    </tbody>
+
+</table>

--- a/souschef/member/templates/client/update/status.html
+++ b/souschef/member/templates/client/update/status.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="header">
-    {% trans 'Status modification' %}
+    {% trans 'Status Modification' %}
 </div>
 <form class="content ui form" id="change-status-form" method="POST" action="">
     {% csrf_token %}
@@ -16,8 +16,8 @@
         {{ form.reason }}
         {% if form.reason.errors %} {{ form.reason.errors }} {% endif %}
     </div>
-    <hr>
-    <p>{% trans 'If you want to schedule a status modification, feel free to fill one or two of theses date fields.' %}</p>
+    <h3>{% trans 'Scheduling' %}</h3>
+    <p>{% trans 'To schedule a status modification, fill one or two of theses date fields:' %}</p>
     <div class="two fields">
         <div class="field">
             <label>{{ form.change_date.label }}</label>
@@ -40,6 +40,13 @@
             {% if form.end_date.errors %} {{ form.end_date.errors }} {% endif %}
         </div>
     </div>
+    <h3>{% trans 'Upcoming Orders' %}</h3>
+    {% if orders %}
+        <p>{% trans 'Please note that this client currently has the following upcoming orders:' %}</p>
+        {% include 'client/partials/order_list.html' %}
+    {% else %}
+        <p>{% trans 'This client has no upcoming orders.' %}</p>
+    {% endif %}
 </form>
 <div class="actions">
     <button class="ui button deny">{% trans "Cancel" %}</button>

--- a/souschef/member/templates/client/view/orders.html
+++ b/souschef/member/templates/client/view/orders.html
@@ -23,41 +23,7 @@
     </h2>
 
     <div class="ui divider"></div>
+    {% include 'client/partials/order_list.html' %}
 
-    <table class="ui very basic stripped celled table">
-        <thead>
-            <th class="sorted descending">{% trans 'Order' %}
-                    <i class="help-text question grey icon link" data-content="{% trans 'A unique identifier for the order.' %}"></i>
-            </th>
-            <th class="">{% trans 'Delivery Date' %}
-                <i class="help-text question grey icon link" data-content="{% trans 'The delivery date planned for the order.' %}"></i>
-            </th>
-            <th class="center aligned">{% trans 'Status' %}
-                <i class="help-text question grey icon link" data-content="{% trans 'The order status' %}"></i>
-            </th>
-            <th class="">{% trans 'Amount' %}
-                <i class="help-text question grey icon link" data-content="{% trans 'Total amount in $CAD.' %}"></i>
-            </th>
-            <th class="">{% trans 'Actions' %}</th>
-          </thead>
-        </thead>
-        <tbody>
-            {% for order in orders %}
-                <tr>
-                    <td><strong><i class="hashtag icon"></i>{{order.id}}</strong></td>
-                    <td>{{order.delivery_date}}</td>
-                    <td class="center aligned">{{order.get_status_display}}</td>
-                    <td><i class="dollar icon"></i>{{order.price}}</td>
-                    <td>
-                        <a class="ui basic icon button"  href="{% url 'order:view' pk=order.id %}"><i class="icon unhide"></i></a>
-                        {% if can_edit_data %}<a class="ui basic icon button"  href="{% url 'order:update' pk=order.id %}"><i class="icon edit"></i></a>{% endif %}
-                        {% if can_edit_data %}<a class="ui basic icon button order-delete" href="#" data-order-id="{{order.id}}"><i class="icon trash"></i></a>{% endif %}
-                    </td>
-                </tr>
-                {% include "order_confirm_delete.html" %}
-            {% endfor %}
-        </tbody>
-
-    </table>
  </div>
 {% endblock %}

--- a/souschef/member/views.py
+++ b/souschef/member/views.py
@@ -1177,10 +1177,13 @@ class ClientStatusScheduler(
 
     def get_context_data(self, **kwargs):
         context = super(ClientStatusScheduler, self).get_context_data(**kwargs)
-        context['client'] = get_object_or_404(
+        context['client'] = client = get_object_or_404(
             Client, pk=self.kwargs.get('pk')
         )
         context['client_status'] = Client.CLIENT_STATUS
+        context['orders'] = client.upcoming_orders.prefetch_related(
+            'orders'
+        )
         return context
 
     def get_initial(self):


### PR DESCRIPTION
As a client program manager, when I change a client status to PAUSED, I
want to be informed of upcoming orders for that client so that I can go
and cancel these orders if needed.

See #64.