### PR TITLE
Fix components edition in admin (#116)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fh:
 
 setuptools.setup(
     name="souschef",
-    version="1.4.4",
+    version="1.4.6",
     license="AGPL-3.0",
     author="Santropol Roulant and Savoir Faire Linux",
     author_email="info@santropolroulant.org",

--- a/souschef/meal/admin.py
+++ b/souschef/meal/admin.py
@@ -20,6 +20,10 @@ class ComponentsInline(admin.TabularInline):
 
 class ComponentIngredientInline(admin.TabularInline):
     model = Component_ingredient
+    fields = ("ingredient",)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).filter(date=None)
 
 
 class IncompatibilityInline(admin.TabularInline):


### PR DESCRIPTION
There was a timeout due to the fact that component ingredients loaded with full history. We now only load ingredients having no date, i.e. ingredients proposed for next kitchen count.

See #116.
