### PR TITLE
feat: add new menu colors for gcloud env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "souschef"
-version = "2.0.0dev11"
+version = "2.0.0dev12"
 authors = [
     { name = "Santropol Roulant and Savoir Faire Linux", email = "info@santropolroulant.org" },
 ]

--- a/souschef/frontend/scss/base/menu.scss
+++ b/souschef/frontend/scss/base/menu.scss
@@ -11,6 +11,22 @@
 
 }
 
-.ui.inverted.menu.staging-color {
+// Prod interne
+.ui.inverted.menu.env-prod {
+    background: #1b1c1d;
+}
+
+// Staging interne
+.ui.inverted.menu.env-staging {
     background: cadetblue;
+}
+
+// Prod cloud
+.ui.inverted.menu.env-prod-cloud {
+    background: #4a235a;
+}
+
+// Staging cloud
+.ui.inverted.menu.env-staging-cloud {
+    background: #1a7a4a;
 }

--- a/souschef/sous_chef/templates/base.html
+++ b/souschef/sous_chef/templates/base.html
@@ -21,14 +21,14 @@
 
 <body>
     <!-- Responsive sidebar menu -->
-    <div class="ui inverted vertical menu {% if SC_ENVIRONMENT_NAME == 'STAGING' %}staging-color{% endif %} left sidebar">
+    <div class="ui inverted vertical menu env-{{ SC_ENVIRONMENT_NAME|lower }} left sidebar">
         {% include "system/menu.html" %}
     </div>
     <!-- Main content grid -->
     <div class="pusher">
         <div class="ui grid container">
             <!-- Non responsive menu -->
-            <div class="ui left fixed vertical inverted menu {% if SC_ENVIRONMENT_NAME == 'STAGING' %}staging-color{% endif %}">
+            <div class="ui left fixed vertical inverted menu env-{{ SC_ENVIRONMENT_NAME|lower }}">
                 {% include "system/menu.html" %}
             </div>
             <!-- Responsive top menu -->


### PR DESCRIPTION
## Résumé

Remplace la classe CSS statique `staging-color` par une classe dynamique `env-{{ SC_ENVIRONMENT_NAME|lower }}`, permettant à chacune des 4 instances de déploiement d'avoir une couleur de menu latéral distincte.

| Instance | `SOUSCHEF_ENVIRONMENT_NAME` | Couleur |
|---|---|---|
| Prod interne | `PROD` | Anthracite `#1b1c1d` |
| Staging interne | `STAGING` | Cadet blue |
| Prod cloud | `PROD-CLOUD` | Violet `#4a235a` |
| Staging cloud | `STAGING-CLOUD` | Vert forêt `#1a7a4a` |

## À faire suite à ce merge

- [ ] Configurer `SOUSCHEF_ENVIRONMENT_NAME=PROD-CLOUD` dans les variables d'environnement de la prod cloud
- [ ] Configurer `SOUSCHEF_ENVIRONMENT_NAME=STAGING-CLOUD` dans les variables d'environnement du staging cloud