### PR TITLE
fix: logout functionality (POST instead of GET)

### DIFF
--- a/souschef/frontend/scss/base/menu.scss
+++ b/souschef/frontend/scss/base/menu.scss
@@ -11,6 +11,24 @@
 
 }
 
+.logout-form {
+    padding: 0 !important;
+}
+
+.logout-button {
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.08);
+    }
+}
+
 // Prod interne
 .ui.inverted.menu.env-prod {
     background: #1b1c1d;

--- a/souschef/sous_chef/settings.py
+++ b/souschef/sous_chef/settings.py
@@ -156,6 +156,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LOGIN_URL = reverse_lazy("page:login")
 LOGIN_REDIRECT_URL = reverse_lazy("page:home")
+LOGOUT_REDIRECT_URL = reverse_lazy("page:login")
 
 AUTHENTICATION_BACKENDS = (
     "rules.permissions.ObjectPermissionBackend",

--- a/souschef/sous_chef/templates/system/menu.html
+++ b/souschef/sous_chef/templates/system/menu.html
@@ -49,7 +49,12 @@
     <!-- The archive link is served by nginx and will not work in a development setup. -->
     <!-- It contains previously generated kitchen counts, labels and route reports. -->
     <a class="item" href="/archive/?C=M&O=D" target="_blank"><i class="folder icon"></i>{% trans 'Archive' %}</a>
-    <a href="{% url 'page:logout' %}" class="item"><i class="sign out icon"></i>{% trans 'Logout' %}</a>
+    <form method="post" action="{% url 'page:logout' %}" class="item logout-form">
+        {% csrf_token %}
+        <button type="submit" class="ui item logout-button">
+            <i class="sign out icon"></i>{% trans 'Logout' %}
+        </button>
+    </form>
 </div>
 <div class="item">
     <strong class="ui center aligned container" style="color:aqua;">


### PR DESCRIPTION
## Fix logout 405 + mauvaise redirection

Depuis Django 5.0, `LogoutView` n'accepte plus les requêtes GET (erreur 405). Remplace le lien de logout par un formulaire POST, et ajoute `LOGOUT_REDIRECT_URL` pour rediriger correctement vers la page de login au lieu de l'admin Django.

**Changements:**
- `menu.html`: lien `<a>` → `<form method="post">` pour le logout
- `settings.py`: ajout de `LOGOUT_REDIRECT_URL = reverse_lazy("page:login")`